### PR TITLE
Leaf 4312 - cancel un-submitted requests

### DIFF
--- a/utility/cancel_requests_x_days_old
+++ b/utility/cancel_requests_x_days_old
@@ -1,6 +1,7 @@
 <script src="../libs/js/LEAF/intervalQueue.js"></script>
 <script>
-var functionDescription = "Cancel Unsubmitted Requests Older than 30 days";
+    var numDays = 30;
+var functionDescription = "Cancel Unsubmitted Requests Older than " + numDays + " days";
 
 function runMassAction() {
     let totalRecords = Object.keys(selectedRecords).length;
@@ -74,6 +75,12 @@ function preparePreview() {
          {name: 'Title', indicatorID: 'title', editable: false, callback: function(data, blob) {
             $('#'+data.cellContainerID).html(blob[data.recordID].title);
          }},
+         /*{name: 'Service', indicatorID: 'service', editable: false, callback: function(data, blob) {
+             $('#'+data.cellContainerID).html(blob[data.recordID].service);
+             if(blob[data.recordID].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
+                 $('#'+data.cellContainerID).css('background-color', '#feffd1');
+             }
+         }},*/
          {name: 'Status', indicatorID: 'currentStatus', editable: false, callback: function(data, blob) {
              var waitText = blob[data.recordID].blockingStepID == 0 ? 'Pending ' : 'Waiting for ';
              var status = '';
@@ -147,7 +154,7 @@ function generateQuery(advSearch) {
         }
     }*/
     query.addDataTerm('stepID', '', '!=', 'submitted', 'AND');
-    query.addDataTerm('dateInitiated', '', '<=', getDaysAgo(30), 'AND');
+    query.addDataTerm('dateInitiated', '', '<=', getDaysAgo(numDays), 'AND');
     query.addDataTerm('deleted', '', '=', 0, 'AND');
 }
     

--- a/utility/cancel_requests_x_days_old
+++ b/utility/cancel_requests_x_days_old
@@ -139,7 +139,6 @@ function preparePreview() {
     
 function generateQuery(advSearch) {
     query.clearTerms();
-    console.log(advSearch);
     
     query.addDataTerm('stepID', '', '!=', 'submitted', 'AND');
     query.addDataTerm('dateInitiated', '', '<=', getDaysAgo(numDays), 'AND');

--- a/utility/cancel_requests_x_days_old
+++ b/utility/cancel_requests_x_days_old
@@ -1,0 +1,212 @@
+<script src="../libs/js/LEAF/intervalQueue.js"></script>
+<script>
+var functionDescription = "Cancel Unsubmitted Requests Older than 30 days";
+
+function runMassAction() {
+    let totalRecords = Object.keys(selectedRecords).length;
+
+    let queue = new intervalQueue();    // Create a queue to help facilitate processing mass actions
+    queue.setConcurrency(3);            // The browser maximum for network requests is typically 6. This affects how many of your functions can run simultaneously.
+    queue.setWorker(function(item) {    // This is executed for each record. Must return $.ajax or Promise
+        document.querySelector('#functionStatus').innerHTML = `Processing ${queue.getLoaded()} of ${totalRecords} records`;
+
+        return $.ajax({
+            type: 'POST',
+            url: `./api/form/${item.recordID}/cancel`,
+            data: {
+                CSRFToken: '<!--{$CSRFToken}-->',
+                comment: 'Canceled by mass action'
+            }
+        });
+    });
+    
+    queue.setOnWorkerError(function(item, reason) { // Errors can be logged here
+        console.log(`Error processing recordID: ${item.recordID}`);
+    });
+    
+    queue.onComplete(function() {
+        document.querySelector('#functionStatus').innerHTML = 'Complete';
+        return 'Complete';
+    });
+    
+    for(let i in selectedRecords) {
+        queue.push(selectedRecords[i]);
+    }
+    
+    queue.start();
+}
+
+function prelaunchCheck() {
+    dialog_confirm.setTitle('Pre-launch check...');
+    dialog_confirm.setContent(`Ready to run ${functionDescription} on <b>${Object.keys(selectedRecords).length}</b> records?`);
+    dialog_confirm.setSaveHandler(function() {
+        dialog_confirm.hide();
+        runMassAction();
+    });
+    dialog_confirm.show();
+    document.querySelector('#confirm_button_cancelchange').focus();
+}
+
+function ready(func) {
+    document.addEventListener("DOMContentLoaded", func);
+}
+
+var selectedRecords = {};
+function preparePreview() {
+    query.onSuccess(function(res) {
+        selectedRecords = res;
+        document.querySelector('#previewStatus').innerHTML = 'Preview of ' + Object.keys(res).length + ' total records';
+        
+        var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+        var grid = new LeafFormGrid('previewGrid', {readOnly: true});
+        grid.setDataBlob(res);
+        grid.setHeaders([
+         {name: 'Date Initiated', indicatorID: 'date', editable: false, callback: function(data, blob) {
+             var date = new Date(blob[data.recordID].date * 1000);
+             var now = new Date();
+             var year = now.getFullYear() != date.getFullYear() ? ' ' + date.getFullYear() : '';
+             var formattedDate = months[date.getMonth()] + ' ' + parseFloat(date.getDate()) + year;
+             $('#'+data.cellContainerID).html(formattedDate);
+             if(blob[data.recordID].userID == "<!--{$userID|unescape|escape:'quotes'}-->") {
+                 $('#'+data.cellContainerID).css('background-color', '#feffd1');
+             }
+         }},
+         {name: 'Title', indicatorID: 'title', editable: false, callback: function(data, blob) {
+            $('#'+data.cellContainerID).html(blob[data.recordID].title);
+         }},
+         {name: 'Status', indicatorID: 'currentStatus', editable: false, callback: function(data, blob) {
+             var waitText = blob[data.recordID].blockingStepID == 0 ? 'Pending ' : 'Waiting for ';
+             var status = '';
+             if(blob[data.recordID].stepID == null && blob[data.recordID].submitted == '0' && blob[data.recordID].lastStatus == null) {
+                 status = '<span style="color: #e00000">Not Submitted</span>';
+             }
+             else if(blob[data.recordID].stepID == null) {
+                 var lastStatus = blob[data.recordID].lastStatus;
+                 if(lastStatus == '') {
+                     lastStatus = '<a href="index.php?a=printview&recordID='+ data.recordID +'">Check Status</a>';
+                 }
+                 status = '<span style="font-weight: bold; color: #e00000;">' + lastStatus + '</span>';
+             }
+             else {
+                 status = waitText + blob[data.recordID].stepTitle;
+             }
+
+             if(blob[data.recordID].deleted > 0) {
+                 status += ', Cancelled';
+             }
+
+             $('#'+data.cellContainerID).html(status);
+             if(blob[data.recordID].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
+                 $('#'+data.cellContainerID).css('background-color', '#feffd1');
+             }
+         }}
+         ]);
+
+        var tGridData = [];
+        for(var i in res) {
+            tGridData.push(res[i]);
+        }
+        grid.setData(tGridData);
+        //grid.sort('recordID', 'desc');
+        grid.renderBody();
+        grid.announceResults();
+
+        $('#header_date').css('width', '60px');
+        $('#header_service').css('width', '150px');
+        $('#header_currentStatus').css('width', '100px');
+
+    });
+    
+    let leafSearch = new LeafFormSearch('searchContainer');
+    leafSearch.setSearchFunc(search => {
+        try {
+            leafSearchTerms = $.parseJSON(search);
+        }
+        catch(err) {
+            return;
+        }
+        
+        generateQuery(leafSearchTerms);
+
+        query.execute();
+    });
+    leafSearch.init();
+    document.querySelector('#'+ leafSearch.getPrefixID() + 'advancedSearchButton').click();
+}
+    
+function generateQuery(advSearch) {
+    query.clearTerms();
+    console.log(advSearch);
+    /*for(var i in advSearch) {
+        if(advSearch[i].id != 'data'
+           && advSearch[i].id != 'dependencyID') {
+            query.addTerm(advSearch[i].id, advSearch[i].operator, advSearch[i].match, advSearch[i].gate);
+        }
+        else {
+            query.addDataTerm(advSearch[i].id, advSearch[i].indicatorID, advSearch[i].operator, advSearch[i].match, advSearch[i].gate);
+        }
+    }*/
+    query.addDataTerm('stepID', '', '!=', 'submitted', 'AND');
+    query.addDataTerm('dateInitiated', '', '<=', getDaysAgo(30), 'AND');
+    query.addDataTerm('deleted', '', '=', 0, 'AND');
+}
+    
+function getDaysAgo(days){
+    var currentDate = new Date();
+    currentDate.setDate(currentDate.getDate()-days);
+    var twoDigitMonth=((currentDate.getMonth()+1)>=10)? (currentDate.getMonth()+1) : '0' + (currentDate.getMonth()+1);
+    var twoDigitDate=((currentDate.getDate())>=10)? (currentDate.getDate()) : '0' + (currentDate.getDate());
+
+    var year = currentDate.getFullYear();
+
+    var ninetyDaysAgo = twoDigitMonth + "/" + twoDigitDate + "/" + year;
+
+    return ninetyDaysAgo;
+}
+
+var query;
+var leafSearchTerms = {};
+var dialog_confirm;
+ready(function() {
+    query = new LeafFormQuery();
+    dialog_confirm = new dialogController('confirm_xhrDialog', 'confirm_xhr', 'confirm_loadIndicator', 'confirm_button_save', 'confirm_button_cancelchange');
+
+    preparePreview();
+    
+    document.querySelector('#btn_runFunction').addEventListener('click', function() {
+        prelaunchCheck();
+    });
+    
+    document.querySelector('#functionName').innerHTML = functionDescription;
+});
+    
+</script>
+
+<div style="width: 60vw; margin: auto">
+    <div id="controlContainer" style="border: 1px solid black; background-color: white; padding: 8px">
+        <h1>Programmatic Mass Action</h1>
+        <p>This site assists developers in running custom functions on LEAF records using a standard API.</p>
+        <ol>
+            <li>Establish a filter and preview records</li>
+            <li>The mass action payload will run on the records in the preview after clicking "Run Function"</li>
+        </ol>
+        <button id="btn_runFunction" class="buttonNorm"><img src="../libs/dynicons/?img=media-playback-start.svg&amp;w=32"/> Run Function</button>
+        <h2>Function Description: <span id="functionName">(Function not loaded)</span></h2>
+        <h2>Status: <span id="functionStatus">(Function not running)</span></h2>
+    </div>
+    <br />
+    <div id="searchContainer" style='visibility: hidden; display: none;'></div>
+    <h2 id="previewStatus"></h2>
+    <div id="previewGrid"></div>
+</div>
+
+<div id="confirm_xhrDialog" style="background-color: #feffd1; border: 1px solid black; visibility: hidden; display: none">
+<form id="confirm_record" enctype="multipart/form-data" action="javascript:void(0);">
+    <div>
+        <div id="confirm_loadIndicator" style="visibility: hidden; position: absolute; text-align: center; font-size: 24px; font-weight: bold; background: white; padding: 16px; height: 100px; width: 360px">Loading... <img src="images/largespinner.gif" alt="loading..." title="loading..." /></div>
+        <div id="confirm_xhr" style="font-size: 130%; width: 400px; height: 120px; padding: 16px; overflow: auto"></div>
+        <div style="position: absolute; left: 10px; font-size: 140%"><button class="buttonNorm" id="confirm_button_cancelchange" style="font-size: 16pt"> 🛑 Stop</button></div>
+        <div style="text-align: right; padding-right: 6px"><button class="buttonNorm" id="confirm_button_save"><span id="confirm_saveBtnText" style="font-size: 16pt"> 🚀 Let's Go!</span></button></div><br />
+    </div>
+</form>
+</div>

--- a/utility/cancel_requests_x_days_old
+++ b/utility/cancel_requests_x_days_old
@@ -1,7 +1,7 @@
 <script src="../libs/js/LEAF/intervalQueue.js"></script>
 <script>
-    var numDays = 30;
-var functionDescription = "Cancel Unsubmitted Requests Older than " + numDays + " days";
+    let numDays = 7;
+let functionDescription = "Cancel Unsubmitted Requests Older than " + numDays + " days";
 
 function runMassAction() {
     let totalRecords = Object.keys(selectedRecords).length;
@@ -17,6 +17,9 @@ function runMassAction() {
             data: {
                 CSRFToken: '<!--{$CSRFToken}-->',
                 comment: 'Canceled by mass action'
+            },
+            error: function(err){
+                console.log(err);
             }
         });
     });
@@ -52,7 +55,7 @@ function ready(func) {
     document.addEventListener("DOMContentLoaded", func);
 }
 
-var selectedRecords = {};
+let selectedRecords = {};
 function preparePreview() {
     query.onSuccess(function(res) {
         selectedRecords = res;
@@ -75,12 +78,6 @@ function preparePreview() {
          {name: 'Title', indicatorID: 'title', editable: false, callback: function(data, blob) {
             $('#'+data.cellContainerID).html(blob[data.recordID].title);
          }},
-         /*{name: 'Service', indicatorID: 'service', editable: false, callback: function(data, blob) {
-             $('#'+data.cellContainerID).html(blob[data.recordID].service);
-             if(blob[data.recordID].userID == '<!--{$userID|unescape|escape:'quotes'}-->') {
-                 $('#'+data.cellContainerID).css('background-color', '#feffd1');
-             }
-         }},*/
          {name: 'Status', indicatorID: 'currentStatus', editable: false, callback: function(data, blob) {
              var waitText = blob[data.recordID].blockingStepID == 0 ? 'Pending ' : 'Waiting for ';
              var status = '';
@@ -114,7 +111,6 @@ function preparePreview() {
             tGridData.push(res[i]);
         }
         grid.setData(tGridData);
-        //grid.sort('recordID', 'desc');
         grid.renderBody();
         grid.announceResults();
 
@@ -144,29 +140,21 @@ function preparePreview() {
 function generateQuery(advSearch) {
     query.clearTerms();
     console.log(advSearch);
-    /*for(var i in advSearch) {
-        if(advSearch[i].id != 'data'
-           && advSearch[i].id != 'dependencyID') {
-            query.addTerm(advSearch[i].id, advSearch[i].operator, advSearch[i].match, advSearch[i].gate);
-        }
-        else {
-            query.addDataTerm(advSearch[i].id, advSearch[i].indicatorID, advSearch[i].operator, advSearch[i].match, advSearch[i].gate);
-        }
-    }*/
+    
     query.addDataTerm('stepID', '', '!=', 'submitted', 'AND');
     query.addDataTerm('dateInitiated', '', '<=', getDaysAgo(numDays), 'AND');
     query.addDataTerm('deleted', '', '=', 0, 'AND');
 }
     
 function getDaysAgo(days){
-    var currentDate = new Date();
+    let currentDate = new Date();
     currentDate.setDate(currentDate.getDate()-days);
-    var twoDigitMonth=((currentDate.getMonth()+1)>=10)? (currentDate.getMonth()+1) : '0' + (currentDate.getMonth()+1);
-    var twoDigitDate=((currentDate.getDate())>=10)? (currentDate.getDate()) : '0' + (currentDate.getDate());
+    let twoDigitMonth=((currentDate.getMonth()+1)>=10)? (currentDate.getMonth()+1) : '0' + (currentDate.getMonth()+1);
+    let twoDigitDate=((currentDate.getDate())>=10)? (currentDate.getDate()) : '0' + (currentDate.getDate());
 
-    var year = currentDate.getFullYear();
+    let year = currentDate.getFullYear();
 
-    var ninetyDaysAgo = twoDigitMonth + "/" + twoDigitDate + "/" + year;
+    let ninetyDaysAgo = twoDigitMonth + "/" + twoDigitDate + "/" + year;
 
     return ninetyDaysAgo;
 }

--- a/utility/cancel_requests_x_days_old
+++ b/utility/cancel_requests_x_days_old
@@ -138,7 +138,7 @@ function preparePreview() {
         query.execute();
     });
     leafSearch.init();
-    document.querySelector('#'+ leafSearch.getPrefixID() + 'advancedSearchButton').click();
+    document.querySelector('#'+ leafSearch.getPrefixID() + 'advancedSearchApply').click();
 }
     
 function generateQuery(advSearch) {


### PR DESCRIPTION
Summary:
A way was needed to cancel requests that have never been submitted or that were sent back and never re-submitted. The advanced search can't get these records because their submitted state is 0 and there is no way to search by initiation date.

Potential Impact:
This will allow someone with LEAF Programmer access to create different scripts to cancel requests based on a certain number of days. There should be no other impact beyond this ability.

Testing:
You will need requests that have not been submitted, or have been sent back to the requester and that were started more than x number of days ago (the number of days depends on the number set in the script)
Load the page.
Click Run Function.
Observe that the requests in the list were canceled.